### PR TITLE
Fix conduction/nonidentical_interface/cylinders tests for nekRS v25 compatibility

### DIFF
--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -1354,9 +1354,7 @@ double
 get_temperature(const int id, const int surf_offset)
 {
   const auto sid = nrs->scalar->nameToIndex.find("temperature")->second;
-  const auto offset = nrs->scalar->fieldOffset();
-  std::vector<dfloat> temperature(S.begin() + sid * offset, S.begin() + (sid + 1) * offset);
-  return temperature[id];
+  return S[id + sid * scalarFieldOffset()];
 }
 
 double

--- a/test/tests/conduction/nonidentical_interface/cylinders/cylinder.oudf
+++ b/test/tests/conduction/nonidentical_interface/cylinders/cylinder.oudf
@@ -1,15 +1,15 @@
-void scalarDirichletConditions(bcData *bc)
+void udfDirichlet(bcData *bc)
 {
   if (bc->id == 1)
-    bc->s = 500.0;
+    bc->sScalar = 500.0;
 }
 
-void scalarNeumannConditions(bcData *bc)
+void udfNeumann(bcData *bc)
 {
   // note: when running with Cardinal, Cardinal will allocate the usrwrk
   // array. If running with NekRS standalone (e.g. nrsmpi), you need to
   // replace the usrwrk with some other value or allocate it youself from
   // the udf and populate it with values.
   if (bc->id == 2)
-    bc->flux = bc->usrwrk[bc->idM];
+    bc->fluxScalar = bc->usrwrk[bc->idxVol];
 }

--- a/test/tests/conduction/nonidentical_interface/cylinders/cylinder.par
+++ b/test/tests/conduction/nonidentical_interface/cylinders/cylinder.par
@@ -8,12 +8,13 @@
   polynomialOrder = 4
   writeControl = steps
   writeInterval = 50
+  scalars = temperature
 
-[VELOCITY]
+[FLUID VELOCITY]
   solver = none
 
-[TEMPERATURE]
-  conductivity = 2.5
-  rhoCp = 1.0
+[SCALAR TEMPERATURE]
+  diffusionCoeff = 2.5
+  transportCoeff = 1.0
   residualTol = 1.0e-10
   boundaryTypeMap = t, f, I, I

--- a/test/tests/conduction/nonidentical_interface/cylinders/cylinder.udf
+++ b/test/tests/conduction/nonidentical_interface/cylinders/cylinder.udf
@@ -4,23 +4,24 @@ void UDF_LoadKernels(occa::properties & kernelInfo)
 {
 }
 
-void UDF_Setup(nrs_t *nrs)
+void UDF_Setup()
 {
-  auto mesh = nrs->cds->mesh[0];
-
-  int n_gll_points = mesh->Np * mesh->Nelements;
-  for (int n = 0; n < n_gll_points; ++n)
-  {
-    nrs->U[n + 0 * nrs->fieldOffset] = 0.0; // x-velocity
-    nrs->U[n + 1 * nrs->fieldOffset] = 0.0; // y-velocity
-    nrs->U[n + 2 * nrs->fieldOffset] = 0.0; // z-velocity
-
-    nrs->P[n] = 0.0; // pressure
-
-    nrs->cds->S[n + 0 * nrs->cds->fieldOffset[0]] = 800.0;
+  auto mesh = nrs->meshV;
+  std::vector<dfloat> U(mesh->dim * nrs->fluid->fieldOffset, 0.0);
+  std::vector<dfloat> P(mesh->Nlocal, 0.0);
+  std::vector<dfloat> temp(mesh->Nlocal, 0.0);
+  for(int n = 0; n < mesh->Nlocal; n++) {
+    U[n + 0 * nrs->fluid->fieldOffset] = 0.0; // x-velocity
+    U[n + 1 * nrs->fluid->fieldOffset] = 0.0; // y-velocity
+    U[n + 2 * nrs->fluid->fieldOffset] = 0.0; // z-velocity
+    P[n] = 0.0; // pressure
+    temp[n] = 800.0;
   }
+  nrs->fluid->o_U.copyFrom(U.data(), U.size());
+  nrs->fluid->o_P.copyFrom(P.data(), P.size());
+  nrs->scalar->o_solution("temperature").copyFrom(temp.data(), temp.size());
 }
 
-void UDF_ExecuteStep(nrs_t *nrs, double time, int tstep)
+void UDF_ExecuteStep(double time, int tstep)
 {
 }

--- a/test/tests/conduction/nonidentical_interface/cylinders/cylinder.usr
+++ b/test/tests/conduction/nonidentical_interface/cylinders/cylinder.usr
@@ -1,0 +1,22 @@
+      subroutine usrdat3
+      include "SIZE"
+      include "TOTAL"
+
+      do ie=1,nelt
+        do ifc=1,2*ndim
+          if(cbc(ifc,ie,1).eq.'EXO')then
+            cbc(ifc,ie,1) = 'W  '
+            cbc(ifc,ie,2) = 'I  '
+            if(bc(5,ifc,ie,1).eq.1)then
+              cbc(ifc,ie,2) = 't  '
+            elseif(bc(5,ifc,ie,1).eq.2)then
+              cbc(ifc,ie,2) = 'f  '
+            endif
+            boundaryID(ifc,ie) = bc(5,ifc,ie,1)
+            boundaryIDt(ifc,ie) = bc(5,ifc,ie,1)
+          endif
+        enddo
+      enddo
+
+      return
+      end

--- a/test/tests/trackv25.md
+++ b/test/tests/trackv25.md
@@ -19,7 +19,7 @@
 | conduction/boundary_and_volume/prism      | pyramid_exact<br>duplicate_temp<br>pyramid                                                   | ❌ Fail<br>✅ Pass<br>❌ Fail   | Uncomment `heavy` to run<br> <br>Timeout error |
 | conduction/identical_volume/cube          | slab_heat_source                                                                             | ❌ Fail                          | Uncomment `heavy` to run    |
 | conduction/zero_flux                      | zero_flux_total<br>zero_flux_total_vpp<br>vpp_disjoint<br> vpp_disjoint_zero<br>mismatch_length<br>nodes_on_shared  | ✅ Pass<br>✅ Pass<br>✅ Pass<br>✅ Pass<br>✅ Pass<br>✅ Pass |                     |
-| conduction/nonidentical_interface/cylinders | cylinder_conduction<br>cylinder_conduction_subcycle<br>cylinder_conduction_reversed<br>cylinder_conduction_min<br>cylinder_conduction_exact  | ⏳ Pending Conversion    |     |
+| conduction/nonidentical_interface/cylinders | cylinder_conduction<br>cylinder_conduction_subcycle<br>cylinder_conduction_reversed<br>cylinder_conduction_mini<br>cylinder_conduction_exact  | ✅ Pass<br>❌ Fail✅ Pass<br>❌ Fail✅ Pass | <br>Timeout error<br><br>Timeout error |
 | conduction/nonidentical_volume/nondimensional | cylinder_heat_source                                                                     | ⏳ Pending Conversion             |     |
 | conduction/nonidentical_volume/cylinder   | cylinder_heat_source<br>cylinder_exact                                                       | ⏳ Pending Conversion             |     |
 | conduction/reverse_cht                    | reverse_cht                                                                                  | ⏳ Pending Conversion             |     |

--- a/test/tests/trackv25.md
+++ b/test/tests/trackv25.md
@@ -19,7 +19,7 @@
 | conduction/boundary_and_volume/prism      | pyramid_exact<br>duplicate_temp<br>pyramid                                                   | ❌ Fail<br>✅ Pass<br>❌ Fail   | Uncomment `heavy` to run<br> <br>Timeout error |
 | conduction/identical_volume/cube          | slab_heat_source                                                                             | ❌ Fail                          | Uncomment `heavy` to run    |
 | conduction/zero_flux                      | zero_flux_total<br>zero_flux_total_vpp<br>vpp_disjoint<br> vpp_disjoint_zero<br>mismatch_length<br>nodes_on_shared  | ✅ Pass<br>✅ Pass<br>✅ Pass<br>✅ Pass<br>✅ Pass<br>✅ Pass |                     |
-| conduction/nonidentical_interface/cylinders | cylinder_conduction<br>cylinder_conduction_subcycle<br>cylinder_conduction_reversed<br>cylinder_conduction_mini<br>cylinder_conduction_exact  | ✅ Pass<br>❌ Fail✅ Pass<br>❌ Fail✅ Pass | <br>Timeout error<br><br>Timeout error |
+| conduction/nonidentical_interface/cylinders | cylinder_conduction<br>cylinder_conduction_subcycle<br>cylinder_conduction_reversed<br>cylinder_conduction_mini<br>cylinder_conduction_exact  | ✅ Pass<br>✅ Pass<br>✅ Pass<br>✅ Pass<br>✅ Pass | <br>Timeout error<br><br>Timeout error |
 | conduction/nonidentical_volume/nondimensional | cylinder_heat_source                                                                     | ⏳ Pending Conversion             |     |
 | conduction/nonidentical_volume/cylinder   | cylinder_heat_source<br>cylinder_exact                                                       | ⏳ Pending Conversion             |     |
 | conduction/reverse_cht                    | reverse_cht                                                                                  | ⏳ Pending Conversion             |     |


### PR DESCRIPTION
- Update test input scripts from v23 to v25 format
- Update test-tracking Markdown list
- Note: two remaining TIMEOUT failures