### PR TITLE
Fix nek_stochastic/shift tests for nekRS v26 compatibility.

### DIFF
--- a/test/tests/nek_stochastic/shift/brick.oudf
+++ b/test/tests/nek_stochastic/shift/brick.oudf
@@ -1,9 +1,9 @@
-@kernel void cFillKernel(const dlong Nelements, const dlong offset, const dfloat value, @restrict dfloat * source)
+@kernel void cFillKernel(const dlong Nelements, const dlong offset, @restrict dfloat * value, @restrict dfloat * source)
 {
   for(dlong e=0;e<Nelements;++e;@outer(0)){
     for(int n=0;n<p_Np;++n;@inner(0)){
       const int id = e*p_Np + n;
-      source[offset + id] = value;
+      source[offset + id] = value[0];
     }
   }
 }
@@ -14,7 +14,7 @@ void udfDirichlet(bcData *bc)
   // array. If running with NekRS standalone (e.g. nrsmpi), you need to
   // replace the usrwrk with some other value or allocate it youself from
   // the udf and populate it with values.
-  bc->sScalar = bc->usrwrk[bc->idM];
+  bc->sScalar = bc->usrwrk[bc->idxVol];
 }
 
 void udfNeumann(bcData *bc)

--- a/test/tests/nek_stochastic/shift/brick.par
+++ b/test/tests/nek_stochastic/shift/brick.par
@@ -8,6 +8,7 @@
   polynomialOrder = 3
   checkpointControl = steps
   checkpointInterval = 2
+  scalars = temperature, 01, 02, 03
 
 [MESH]
   file = ../../common_inputs/brick2.re2
@@ -21,13 +22,13 @@
 [SCALAR TEMPERATURE]
   solver = none
 
-[SCALAR01]
+[SCALAR 01]
   boundaryTypeMap = t, t, t, t, t, f
   residualTol = 1e-6
-  diffusivity = 1000.0
+  diffusionCoeff = 1000.0
 
-[SCALAR02]
+[SCALAR 02]
   solver = none
 
-[SCALAR03]
+[SCALAR 03]
   solver = none

--- a/test/tests/nek_stochastic/shift/brick.udf
+++ b/test/tests/nek_stochastic/shift/brick.udf
@@ -1,11 +1,13 @@
 #include "udf.hpp"
 
-static occa::kernel cFillKernel;
+#ifdef __okl__
+#include "brick.oudf"
+#endif
+
 static double * slice;
 
-void UDF_LoadKernels(deviceKernelProperties occa::properties & kernelInfo)
+void UDF_LoadKernels(occa::properties& kernelInfo)
 {
-  cFillKernel = oudfBuildKernel(kernelInfo, "cFillKernel");
 }
 
 void UDF_Setup()
@@ -15,10 +17,9 @@ void UDF_Setup()
     slice[i] = 1.5;
 }
 
-void UDF_ExecuteStep(nrs_t *nrs, double time, int tstep)
+void UDF_ExecuteStep(double time, int tstep)
 {
   mesh_t *mesh = nrs->meshV;
-  cds_t *cds = nrs->cds;
 
   // note: when running with Cardinal, Cardinal will allocate the usrwrk
   // array. If running with NekRS standalone (e.g. nrsmpi), you need to
@@ -27,9 +28,13 @@ void UDF_ExecuteStep(nrs_t *nrs, double time, int tstep)
 
   // set scalar1 value, which should not be affected by the incoming data from MOOSE
   if (tstep == 0)
-    nrs->o_usrwrk.copyFrom(slice, nrs->fieldOffset * sizeof(dfloat));
+    platform->app->bc->o_usrwrk.copyFrom(slice, nrs->fieldOffset);
 
   // set scalar2 and scalar3 values
-  cFillKernel(mesh->Nelements, 2 * nrs->fieldOffset, nrs->usrwrk[1 * nrs->fieldOffset + 0], nrs->cds->o_S);
-  cFillKernel(mesh->Nelements, 3 * nrs->fieldOffset, nrs->usrwrk[1 * nrs->fieldOffset + 1], nrs->cds->o_S);
+  const size_t idx2 = 1 * nrs->fieldOffset + 0;
+  const size_t idx3 = 1 * nrs->fieldOffset + 1;
+  auto o_val2 = platform->app->bc->o_usrwrk.slice(idx2, 1);
+  auto o_val3 = platform->app->bc->o_usrwrk.slice(idx3, 1);
+  cFillKernel(mesh->Nelements, 2 * nrs->fieldOffset, o_val2, nrs->scalar->o_S);
+  cFillKernel(mesh->Nelements, 3 * nrs->fieldOffset, o_val3, nrs->scalar->o_S);
 }


### PR DESCRIPTION
Fix several minor typos that prevented the case from running (e.g. `SCALAR01` → `SCALAR 01`, `idM` → `idxVol`).

Additionally, make `cFillKernel` consistent with the implementation in `nek_stochastic/ethier.udf`. 
Replace direct `nrs->usrwrk` usage with single-element slices of the `o_usrwrk` device array.