### PR TITLE
Update source code to enable nek_stochastic/driver_multi_fld test to PASS

### DIFF
--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -113,10 +113,10 @@ write_field_file(const std::string & prefix, const dfloat time, const int & step
 
   const auto outXYZ = platform->options.compareArgs("CHECKPOINT OUTPUT MESH", "TRUE");
 
-  if (!checkpointWriter->isInitialized()) {
-    auto visMesh = entireMesh();
-    checkpointWriter->open(visMesh, iofld::mode::write, prefix.c_str());
+  auto visMesh = entireMesh();
+  checkpointWriter->open(visMesh, iofld::mode::write, prefix.c_str());
 
+  if (!checkpointWriter->isInitialized()) {
     if (nrs->fluid) {
       if (platform->options.compareArgs(upperCase(nrs->fluid->name) + " CHECKPOINTING", "TRUE")) {
         std::vector<occa::memory> o_V;

--- a/src/base/NekRSProblem.C
+++ b/src/base/NekRSProblem.C
@@ -253,7 +253,7 @@ NekRSProblem::writeFieldFile(const Real & step_end_time, const int & step) const
     auto full_path = _app.getOutputFileBase();
     std::string last_element(full_path.substr(full_path.rfind(name) + name.size()));
 
-    auto prefix = fieldFilePrefix(std::stoi(last_element));
+    auto prefix = fieldFilePrefix(std::stoi(last_element)) + casename();
 
     nekrs::write_field_file(prefix, t, step);
   }

--- a/test/tests/nek_stochastic/tests
+++ b/test/tests/nek_stochastic/tests
@@ -21,7 +21,7 @@
     # runs multiple sim
     max_parallel = 1
 
-    check_files = 'a00ethier0.f00001 a01ethier0.f00001 a02ethier0.f00001'
+    check_files = 'a00ethier0.f00000 a01ethier0.f00000 a02ethier0.f00000'
     requirement = "The system shall stochastic values to be sent from MOOSE to NekRS and write unique "
                   "NekRS field files for each. By limiting this test to fewer MPI ranks than Apps, we "
                   "also check that we still get the correct naming scheme"


### PR DESCRIPTION
The changes made are:

- Add the case name to the prefix when writing field files. In v26, `checkpointWriter` (an `iofldFactory`) no longer appends the case name automatically, so the full prefix must be passed to `write_field_file()`. Without this, files are written as `a00.f00000` instead of `a00casename.f00000`. Including the case name restores the v23 naming behavior.

- Move the `checkPointWriter()` call outside of the `isInitialized() `conditional block. If it is called only once during initialization, all subsequent MultiApp instances inherit the first instance's prefix, producing files such as `a00ethier0.f00000`, `a00ethier0.f00001`, `a00ethier0.f00002` instead of `a00ethier0.f00000,` `a01ethier0.f00000`, `a02ethier0.f00000`. This change ensures each MultiApp instance configures its own writer and preserves the expected v23 behavior.

- Update the expected file names for the `test:nek_stochastic.driver_multi_fld `test. In v23, field files started at `.f00001`, while the new method starts numbering at `.f00000`.