### PR TITLE
Update userobjects/side/nondimensional test input scripts for NekRS v26 compatibility + proposed bug fix

### DIFF
--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -789,8 +789,7 @@ centroidFace(int local_elem_id, int local_face_id)
   double mass = 0.0;
 
   int offset = local_elem_id * mesh->Nfaces * mesh->Nfp + local_face_id * mesh->Nfp;
-
-  for (int v = 0; v < mesh->Np; ++v)
+  for (int v = 0; v < mesh->Nfp; ++v)
   {
     int id = mesh->vmapM[offset + v];
     double mass_matrix = sgeo[mesh->Nsgeo * (offset + v) + WSJID];

--- a/test/tests/userobjects/side/nondimensional/sfr_7pin.par
+++ b/test/tests/userobjects/side/nondimensional/sfr_7pin.par
@@ -7,6 +7,7 @@
   checkpointInterval = 25
   dealiasing = yes
   polynomialOrder = 3
+  scalars = temperature
 
 [FLUID VELOCITY]
   solver = none

--- a/test/tests/userobjects/side/nondimensional/sfr_7pin.udf
+++ b/test/tests/userobjects/side/nondimensional/sfr_7pin.udf
@@ -9,34 +9,38 @@ void UDF_Setup()
   // set initial conditions for the velocity, temperature, and pressure. Because
   // we turn off the solves, we're just doing postprocessing of whatever we set
   // for the initial conditions
-  mesh_t * mesh = nrs->cds->mesh[0];
+  auto mesh = nrs->meshV;
+  auto &scalar = nrs->scalar;
+
+  std::vector<dfloat> U(nrs->fluid->fieldOffsetSum, 0.0);
+  std::vector<dfloat> P(mesh->Nlocal, 0.0);
+  std::vector<dfloat> T(mesh->Nlocal, 0.0);
 
   // loop over all the GLL points and assign directly to the solution arrays by
   // indexing according to the field offset necessary to hold the data for each
   // solution component
-  int n_gll_points = mesh->Np * mesh->Nelements;
-  for (int n = 0; n < n_gll_points; ++n)
-  {
+  auto [x, y, z] = mesh->xyzHost();
+  for(int n = 0; n < mesh->Nlocal; n++) {
     // mesh is in non-dimensional coordinates
-    dfloat x = mesh->x[n];
-    dfloat y = mesh->y[n];
-    dfloat z = mesh->z[n];
-
     dfloat Lref = 7.646e-3;
-
-    dfloat xdim = x * Lref;
-    dfloat ydim = y * Lref;
-    dfloat zdim = z * Lref;
+    dfloat xdim = x[n] * Lref;
+    dfloat ydim = y[n] * Lref;
+    dfloat zdim = z[n] * Lref;
 
     // same ICs as in ../dimensional, except that we've non-dimensionalized
     // with some arbitrary characteristic scales
-    nrs->U[n + 0 * nrs->fieldOffset] = xdim / 2.0;
-    nrs->U[n + 1 * nrs->fieldOffset] = ydim / 2.0;
-    nrs->U[n + 2 * nrs->fieldOffset] = exp(zdim) / 2.0;
-
+    U[n + 0 * nrs->fluid->fieldOffset] = xdim / 2.0;
+    U[n + 1 * nrs->fluid->fieldOffset] = ydim / 2.0;
+    U[n + 2 * nrs->fluid->fieldOffset] = exp(zdim) / 2.0;
     dfloat kp = 834.5 * 2.0 * 2.0;
-    nrs->P[n] = (xdim+ydim+zdim) / kp;
-
-    nrs->cds->S[n + 0 * nrs->cds->fieldOffset[0]] = (xdim+ydim+zdim - 100.0) / 50.0;
+    P[n] = (xdim+ydim+zdim) / kp;
+    T[n] = (xdim+ydim+zdim - 100.0) / 50.0;
   }
+  nrs->fluid->o_U.copyFrom(U.data(), U.size());
+  nrs->fluid->o_P.copyFrom(P.data(), P.size());
+  nrs->scalar->o_solution("temperature").copyFrom(T.data(), T.size());
+}
+
+void UDF_ExecuteStep(double time, int tstep)
+{
 }

--- a/test/tests/userobjects/side/nondimensional/tests
+++ b/test/tests/userobjects/side/nondimensional/tests
@@ -1,7 +1,7 @@
 [Tests]
   [precompile]
     type = RunCommand
-    command = '${NEKRS_HOME}/bin/nrspre sfr_7pin 1'
+    command = '${NEKRS_HOME}/bin/nekrs --build-only 1 sfr_7pin'
     requirement = "The system shall precompile a Nek case in preparation for a multi-input simulation."
     capabilities = 'nekrs'
     use_shell = True
@@ -15,6 +15,5 @@
                   "../dimensional. The user object averages/integrals computed here exactly match."
     prereq = precompile
     capabilities = 'nekrs'
-    skip = 'Need to resolve precompile issues'
   []
 []


### PR DESCRIPTION
**Summary**

Update the userobjects/side/nondimensional test inputs for compatibility with NekRS v26 and propose a fix for a potential face-node indexing bug observed during testing.

**Changes**

- Update `.par` and `.udf `files to match NekRS v26 expectations.
- Replace the `nrspre` call (which no longer appears to be built in v26) with `nekrs --build-only.`
- Remove the `skip` from the nondim test so it is exercised again.
- Propose a fix in `centroidFace` by changing the loop bound from `mesh->Np` to `mesh->Nfp`.

**Proposed bug fix**

`centroidFace` previously iterated over `mesh->Np` (nodes per element) while indexing face-node data using offsets based on `mesh->Nfaces * mesh->Nfp`. During testing this was observed to access invalid entries (e.g. for `x[id]`) which lead to segfaults.

The change restricts the loop to `mesh->Nfp`, ensuring the routine iterates only over nodes belonging to the specified face.

**Current status**

- The precompile test now passes.
- The nondim test runs but fails due to small (~1.0e-02) relative differences in the solution compared to `gold`.