### PR TITLE
Update nek_errors/deformation test input scripts for NekRS v26 compatibility + source code updates

### DIFF
--- a/src/base/NekInterface.C
+++ b/src/base/NekInterface.C
@@ -203,13 +203,13 @@ hasVariableDt()
 bool
 hasBlendingSolver()
 {
-  return !platform->options.compareArgs("MESH SOLVER", "NONE") && hasMovingMesh();
+  return !platform->options.compareArgs("GEOM SOLVER", "NONE") && hasMovingMesh();
 }
 
 bool
 hasUserMeshSolver()
 {
-  return platform->options.compareArgs("MESH SOLVER", "NONE") && hasMovingMesh();
+  return platform->options.compareArgs("GEOM SOLVER", "NONE") && hasMovingMesh();
 }
 
 bool
@@ -1281,7 +1281,7 @@ isHeatFluxBoundary(const int boundary)
 bool
 isMovingMeshBoundary(const int boundary)
 {
-  auto bcType = platform->app->bc->typeId(boundary, "mesh");
+  auto bcType = platform->app->bc->typeId(boundary, "geom");
   return bcType == bdryBase::bcType_udfDirichlet;
 }
 

--- a/src/transfers/NekMeshDeformation.C
+++ b/src/transfers/NekMeshDeformation.C
@@ -66,7 +66,7 @@ NekMeshDeformation::NekMeshDeformation(const InputParameters & parameters)
     mooseWarning(
         "Your NekRSMesh has 'displacements', but '" + _nek_problem.casename() +
         ".par' does not have a\n"
-        "solver in the [MESH] block! The displacements transferred to NekRS will be unused.");
+        "solver in the [GEOM] block! The displacements transferred to NekRS will be unused.");
 
   if (nekrs::hasMovingMesh() && _nek_mesh->exactMirror())
     mooseError("An exact mesh mirror is not yet implemented for the boundary mesh solver.");
@@ -90,7 +90,7 @@ NekMeshDeformation::NekMeshDeformation(const InputParameters & parameters)
   auto boundary = _nek_mesh->boundary();
   if (!boundary && nekrs::hasBlendingSolver())
     mooseError("'" + _nek_problem.casename() +
-               ".par' has a solver in the [MESH] block. This solver uses\n"
+               ".par' has a solver in the [GEOM] block. This solver uses\n"
                "boundary displacement values from MOOSE to move the NekRS mesh. Please indicate\n"
                "the 'boundary' for which mesh motion is coupled from MOOSE to NekRS.");
 
@@ -111,13 +111,13 @@ NekMeshDeformation::NekMeshDeformation(const InputParameters & parameters)
                  "boundary in '" +
                  _nek_problem.casename() +
                  ".par'\nto be of the type 'codedFixedValue'"
-                 " in the [MESH] block.");
+                 " in the [GEOM] block.");
   }
 
   if (!_nek_mesh->volume() && nekrs::hasUserMeshSolver())
     mooseError(
         "'" + _nek_problem.casename() +
-        ".par' has 'solver = user' in the [MESH] block. With this solver,\n"
+        ".par' has 'solver = user' in the [GEOM] block. With this solver,\n"
         "displacement values are sent to every GLL point in NekRS's volume. If you only are "
         "building\n"
         "a boundary mesh mirror, it's possible that some displacement values could result\n"

--- a/test/tests/nek_errors/deformation/elast_nomv.par
+++ b/test/tests/nek_errors/deformation/elast_nomv.par
@@ -7,11 +7,14 @@ timeStepper = tombo2
 checkpointInterval = 100
 oudf = "nekbox_elast.oudf"
 udf = "nekbox.udf"
+scalars = temperature
 
 [MESH]
-boundaryTypeMap = zeroValue,zeroValue,zeroValue,zeroValue,zeroValue,zeroValue
-solver = pcg+block
 file = "nekbox.re2"
+
+[GEOM]
+boundaryTypeMap = zeroDirichlet,zeroDirichlet,zeroDirichlet,zeroDirichlet,zeroDirichlet,zeroDirichlet
+solver = pcg+block
 
 [PROBLEMTYPE]
 stressFormulation = true
@@ -22,7 +25,7 @@ residualTol = 1e-4
 [FLUID VELOCITY]
 density = 1.0
 viscosity = -100.0
-boundaryTypeMap = zeroValue,codedFixedValue,zeroValue,zeroValue,zeroValue,zeroGradient
+boundaryTypeMap = zeroDirichlet,udfDirichlet,zeroDirichlet,zeroDirichlet,zeroDirichlet,zeroNeumann
 residualTol = 1e-5
 
 [SCALAR TEMPERATURE]

--- a/test/tests/nek_errors/deformation/nekbox.oudf
+++ b/test/tests/nek_errors/deformation/nekbox.oudf
@@ -1,6 +1,6 @@
-void velocityDirichletConditions(bcData *bc)
+void udfDirichlet(bcData *bc)
 {
-  bc->u = 0.0;
-  bc->v = 0.0;
-  bc->w = 0.0;
+  bc->uxFluid = 0.0;
+  bc->uyFluid = 0.0;
+  bc->uzFluid = 0.0;
 }

--- a/test/tests/nek_errors/deformation/nekbox.udf
+++ b/test/tests/nek_errors/deformation/nekbox.udf
@@ -7,23 +7,25 @@ void UDF_LoadKernels(occa::properties& kernelInfo)
 
 void UDF_Setup()
 {
-  mesh_t* mesh = nrs->_mesh;
-  int num_quadrature_points = mesh->Np * mesh->Nelements;
+  auto mesh = nrs->meshV;
 
-  for (int n = 0; n < num_quadrature_points; n++) {
-    float xx = mesh->x[n];
-    float yy = mesh->y[n];
-    float zz = mesh->z[n];
+  std::vector<dfloat> U(nrs->fluid->fieldOffsetSum, 0.0);
+  std::vector<dfloat> P(mesh->Nlocal, 0.0);
+  std::vector<dfloat> T(mesh->Nlocal, 0.0);
 
-    nrs->U[n + 0 * nrs->fieldOffset] = 0;
-    nrs->U[n + 1 * nrs->fieldOffset] = 0;
-    nrs->U[n + 2 * nrs->fieldOffset] = 0;
-    nrs->P[n] = 1.0;
-
-    nrs->cds->S[n + 0 * nrs->cds->fieldOffset[0]] = 0.0;
+  for (int n = 0; n < mesh->Nlocal; n++)
+  {
+    U[n + 0 * nrs->fieldOffset] = 0.0;
+    U[n + 1 * nrs->fieldOffset] = 0.0;
+    U[n + 2 * nrs->fieldOffset] = 0.0;
+    P[n] = 1.0;
+    T[n] = 0.0;
   }
+  nrs->fluid->o_U.copyFrom(U.data(), U.size());
+  nrs->fluid->o_P.copyFrom(P.data(), P.size());
+  nrs->scalar->o_solution("temperature").copyFrom(T.data(), T.size());
 }
 
-void UDF_ExecuteStep(nrs_t *nrs, double time, int tstep)
+void UDF_ExecuteStep(double time, int tstep)
 {
 }

--- a/test/tests/nek_errors/deformation/nomesh_solver.par
+++ b/test/tests/nek_errors/deformation/nomesh_solver.par
@@ -7,13 +7,16 @@
   checkpointInterval = 1
   oudf = "nekbox.oudf"
   udf = "nekbox.udf"
+  scalars = temperature
 
 [MESH]
-  solver = none
   file = "nekbox.re2"
 
+[GEOM]
+  solver = none
+
 [PROBLEMTYPE]
-  stressFormulation = true
+  stressFormulation = false
 
 [FLUID PRESSURE]
   residualTol = 1e-4

--- a/test/tests/nek_errors/deformation/user/user.par
+++ b/test/tests/nek_errors/deformation/user/user.par
@@ -10,9 +10,12 @@
   checkpointInterval = 1
   oudf = "../nekbox.oudf"
   udf = "../nekbox.udf"
+  scalars = temperature
+
+[GEOM]
+  solver = user
 
 [MESH]
-  solver = user
   file = "../nekbox.re2"
 
 [FLUID VELOCITY]


### PR DESCRIPTION
**Changes**

- Update source code by replacing references to the v23 `MESH` `solver`/`field` with the v26 `GEOM` `solver`/`field`.
- Update input scripts for v26 compatibility, including separating the `[MESH]` and `[GEOM]` blocks in the `.par ` files.

**Note:**

The only non-routine change to the input scripts is setting `stressFormulation = false` in `nomesh_solver.par` (previously `true`).

In v23, an internal consistency check enforces `VELOCITY BLOCK SOLVER` to be `true` when  `VELOCITY STRESSFORMULATION` is `true`.  See: https://github.com/neams-th-coe/nekRS/blob/48e408eb9a1f4de674efd243a982c84300c792e4/src/setup/setup.cpp#L172.

In v26, the same check instead throws an error if the settings are inconsistent. As a result, the wrong error was being triggered for this test case because the consistency check occurs before the expected failure. See: https://github.com/Nek5000/nekRS/blob/96b3cf9e5bacede16568826c04a21bc0fe50dc7d/src/app/nrs/nrs.cpp#L157.

Since the velocity solver is explicitly set to `none` for this problem, I believe setting `stressFormulation = false` should be inconsequential for the purposes of this test.